### PR TITLE
Scale layout proportionally for 4K and 2K screens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -147,4 +147,3 @@ body {
 .animate-fade-in-scale {
   animation: scale-in 1s ease-out both;
 }
-

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,15 +20,15 @@ export default async function Home() {
       <ThemeSelector />
 
       <div className="relative z-10 flex h-dvh flex-col justify-between">
-        <main className="flex-1 min-h-0 overflow-y-auto px-8 pt-12 min-[1440px]:px-[8vw] min-[1440px]:pt-[8vh] max-w-[550px] min-[1440px]:max-w-[700px]">
+        <main className="flex-1 min-h-0 overflow-y-auto px-8 pt-12 min-[1440px]:px-[8vw] min-[1440px]:pt-[8vh] min-[2560px]:px-[6vw] min-[2560px]:pt-[6vh] max-w-[550px] min-[1440px]:max-w-[700px] min-[2560px]:max-w-[50vw]">
           <Header />
         </main>
 
-        <div className="shrink-0 px-8 min-[1440px]:px-[8vw]">
+        <div className="shrink-0 px-8 min-[1440px]:px-[8vw] min-[2560px]:px-[6vw]">
           <AnnouncementBar config={announcementConfig} />
 
-          <footer className="py-6 border-t border-poster-dark/8">
-            <div className="flex flex-wrap items-center gap-8 min-[768px]:gap-12">
+          <footer className="py-6 min-[2560px]:py-10 border-t border-poster-dark/8">
+            <div className="flex flex-wrap items-center gap-8 min-[768px]:gap-12 min-[2560px]:gap-16">
               <div
                 className="animate-fade-in-up"
                 style={{ animationDelay: "0.7s" }}

--- a/components/announcementBar/announcementBar.tsx
+++ b/components/announcementBar/announcementBar.tsx
@@ -66,14 +66,14 @@ export default function AnnouncementBar({ config }: AnnouncementBarProps) {
             {isExternal ? (
               <a
                 {...linkProps}
-                className="flex items-center gap-2 text-[0.75rem] text-poster-dark/50 leading-relaxed transition-colors hover:text-poster-dark"
+                className="flex items-center gap-2 text-[0.75rem] min-[2560px]:text-[0.8vw] text-poster-dark/50 leading-relaxed transition-colors hover:text-poster-dark"
               >
                 {linkContent}
               </a>
             ) : (
               <Link
                 {...linkProps}
-                className="flex items-center gap-2 text-[0.75rem] text-poster-dark/50 leading-relaxed transition-colors hover:text-poster-dark"
+                className="flex items-center gap-2 text-[0.75rem] min-[2560px]:text-[0.8vw] text-poster-dark/50 leading-relaxed transition-colors hover:text-poster-dark"
               >
                 {linkContent}
               </Link>

--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -56,12 +56,12 @@ export default async function Header() {
   };
 
   return (
-    <header className="site-header flex flex-col items-start w-full gap-6">
+    <header className="site-header flex flex-col items-start w-full gap-6 min-[2560px]:gap-10">
       <div
-        className="flex items-center gap-4 animate-fade-in-up"
+        className="flex items-center gap-4 min-[2560px]:gap-6 animate-fade-in-up"
         style={{ animationDelay: "0.05s" }}
       >
-        <section className="avatar h-14 w-14 shrink-0 rounded-sm">
+        <section className="avatar h-14 w-14 min-[2560px]:h-[4vw] min-[2560px]:w-[4vw] shrink-0 rounded-sm">
           <Image
             src={headerContent.image.src}
             alt={headerContent.image.alt}
@@ -72,20 +72,20 @@ export default async function Header() {
         </section>
 
         <div>
-          <h1 className="font-bold text-[clamp(1.6rem,3vw,2.4rem)] text-poster-dark leading-none tracking-tight">
+          <h1 className="font-bold text-[clamp(1.6rem,3vw,2.4rem)] min-[2560px]:text-[3.2vw] text-poster-dark leading-none tracking-tight">
             {headerContent.title}
           </h1>
           <TextScramble
             text={_domain}
             delay={0.4}
             duration={800}
-            className="text-[0.65rem] text-poster-dark/30 uppercase tracking-[0.2em]"
+            className="text-[0.65rem] min-[2560px]:text-[0.9vw] text-poster-dark/30 uppercase tracking-[0.2em]"
           />
         </div>
       </div>
 
       <p
-        className="text-[clamp(0.85rem,1.1vw,1rem)] text-poster-dark/50 leading-relaxed max-w-[420px] min-[1440px]:max-w-[560px] text-pretty animate-fade-in-up"
+        className="text-[clamp(0.85rem,1.1vw,1rem)] min-[2560px]:text-[1.15vw] text-poster-dark/50 leading-relaxed max-w-[420px] min-[1440px]:max-w-[560px] min-[2560px]:max-w-[35vw] text-pretty animate-fade-in-up"
         style={{ animationDelay: "0.2s" }}
       >
         Father of two, software developer, fixed gear cyclist and music

--- a/components/listening/listeningCard.tsx
+++ b/components/listening/listeningCard.tsx
@@ -20,10 +20,10 @@ export default function ListeningCard({
   isPlaying,
 }: ListeningCardProps) {
   return (
-    <div className="listening flex items-start gap-4 min-w-0 max-w-[300px] min-[1440px]:max-w-[400px]">
+    <div className="listening flex items-start gap-4 min-w-0 max-w-[300px] min-[1440px]:max-w-[400px] min-[2560px]:max-w-[20vw]">
       {/* Cover art — small, graphic */}
       <motion.div
-        className="relative h-[56px] w-[56px] shrink-0 rounded-lg overflow-hidden"
+        className="relative h-[56px] w-[56px] min-[2560px]:h-[3.5vw] min-[2560px]:w-[3.5vw] shrink-0 rounded-lg overflow-hidden"
         whileHover={{ scale: 1.05 }}
         transition={{ type: "spring", stiffness: 400, damping: 15 }}
       >
@@ -55,7 +55,7 @@ export default function ListeningCard({
 
       {/* Track info — typographic */}
       <div className="flex flex-col gap-0.5 min-w-0">
-        <span className="flex items-center gap-1.5 text-poster-dark/40 text-[0.65rem] font-bold uppercase tracking-[0.15em]">
+        <span className="flex items-center gap-1.5 text-poster-dark/40 text-[0.65rem] min-[2560px]:text-[0.7vw] font-bold uppercase tracking-[0.15em]">
           {isPlaying ? (
             <Disc
               size={12}
@@ -66,10 +66,10 @@ export default function ListeningCard({
           ) : null}
           {label}
         </span>
-        <span className="font-bold text-poster-dark text-sm leading-tight truncate">
+        <span className="font-bold text-poster-dark text-sm min-[2560px]:text-[1vw] leading-tight truncate">
           {trackName}
         </span>
-        <span className="text-poster-dark/45 text-[0.7rem] uppercase tracking-widest truncate">
+        <span className="text-poster-dark/45 text-[0.7rem] min-[2560px]:text-[0.8vw] uppercase tracking-widest truncate">
           {artist}
         </span>
       </div>

--- a/components/omakaseSeal/omakaseSeal.tsx
+++ b/components/omakaseSeal/omakaseSeal.tsx
@@ -5,7 +5,7 @@ export default function OmakaseSeal() {
     <>
       {/* Desktop: vertical hero on the right */}
       <div
-        className="pointer-events-none fixed right-[6vw] top-0 z-10 hidden h-screen items-center min-[1440px]:flex"
+        className="pointer-events-none fixed right-[6vw] min-[2560px]:right-[8vw] top-0 z-10 hidden h-screen items-center min-[1440px]:flex"
         aria-hidden="true"
       >
         <div className="flex flex-col items-center gap-0">

--- a/components/social/social.tsx
+++ b/components/social/social.tsx
@@ -41,35 +41,38 @@ export default function Social() {
     ],
   };
 
+  const iconClass =
+    "h-[22px] w-[22px] min-[2560px]:h-[1.5vw] min-[2560px]:w-[1.5vw]";
+
   const iconMap: Record<string, React.ReactNode> = {
     youtube: (
       <YoutubeLogo
-        size={22}
         weight="bold"
+        className={iconClass}
       />
     ),
     github: (
       <GithubLogo
-        size={22}
         weight="bold"
+        className={iconClass}
       />
     ),
     linkedin: (
       <LinkedinLogo
-        size={22}
         weight="bold"
+        className={iconClass}
       />
     ),
     strava: (
       <Bicycle
-        size={22}
         weight="bold"
+        className={iconClass}
       />
     ),
   };
 
   return (
-    <section className="social flex items-center gap-6">
+    <section className="social flex items-center gap-6 min-[2560px]:gap-10">
       {socialContent.links.map((link, index) => (
         <MagneticHover key={link.id}>
           <motion.a
@@ -82,7 +85,7 @@ export default function Social() {
             whileTap={{ scale: 0.95 }}
           >
             {iconMap[link.icon]}
-            <span className="text-[0.7rem] font-bold uppercase tracking-widest hidden min-[480px]:inline">
+            <span className="text-[0.7rem] min-[2560px]:text-[0.8vw] font-bold uppercase tracking-widest hidden min-[480px]:inline">
               {link.title}
             </span>
           </motion.a>

--- a/components/status/status.tsx
+++ b/components/status/status.tsx
@@ -16,8 +16,8 @@ import type {
   IStatusData,
 } from "@/components/status/status.d";
 
-const ICON_SIZE = 18;
 const ICON_WEIGHT = "bold" as const;
+const ICON_CLASS = "mr-1.5 h-[18px] w-[18px] min-[2560px]:h-[1.2vw] min-[2560px]:w-[1.2vw]";
 
 const statuses: Record<string, IStatus> = {
   weekend: {
@@ -25,8 +25,7 @@ const statuses: Record<string, IStatus> = {
     text: "Enjoying the weekend.",
     icon: (
       <SmileyWink
-        className="mr-1.5"
-        size={ICON_SIZE}
+        className={ICON_CLASS}
         weight={ICON_WEIGHT}
       />
     ),
@@ -36,8 +35,7 @@ const statuses: Record<string, IStatus> = {
     text: "Sleeping.",
     icon: (
       <BatteryWarning
-        className="mr-1.5"
-        size={ICON_SIZE}
+        className={ICON_CLASS}
         weight={ICON_WEIGHT}
       />
     ),
@@ -47,8 +45,7 @@ const statuses: Record<string, IStatus> = {
     text: "Having lunch.",
     icon: (
       <BatteryCharging
-        className="mr-1.5"
-        size={ICON_SIZE}
+        className={ICON_CLASS}
         weight={ICON_WEIGHT}
       />
     ),
@@ -58,8 +55,7 @@ const statuses: Record<string, IStatus> = {
     text: "At work.",
     icon: (
       <Laptop
-        className="mr-1.5"
-        size={ICON_SIZE}
+        className={ICON_CLASS}
         weight={ICON_WEIGHT}
       />
     ),
@@ -69,8 +65,7 @@ const statuses: Record<string, IStatus> = {
     text: "Enjoying the life.",
     icon: (
       <SunHorizon
-        className="mr-1.5"
-        size={ICON_SIZE}
+        className={ICON_CLASS}
         weight={ICON_WEIGHT}
       />
     ),
@@ -80,8 +75,7 @@ const statuses: Record<string, IStatus> = {
     text: "Listening to music.",
     icon: (
       <MusicNote
-        className="mr-1.5"
-        size={ICON_SIZE}
+        className={ICON_CLASS}
         weight={ICON_WEIGHT}
       />
     ),
@@ -95,7 +89,7 @@ export default function Status({ dataFromAPI }: IStatusComponentProps) {
   };
 
   return statusContent.status ? (
-    <span className="status flex items-center text-poster-dark/50 text-[0.8rem] tracking-wide uppercase">
+    <span className="status flex items-center text-poster-dark/50 text-[0.8rem] min-[2560px]:text-[1vw] tracking-wide uppercase">
       <span className={`flex items-center ${statusContent.status.color}`}>
         {statusContent.status.icon}
         <span className="font-bold mr-1">{statusContent.time}</span>

--- a/components/strava/strava.tsx
+++ b/components/strava/strava.tsx
@@ -40,20 +40,20 @@ export default async function Strava({ type }: StravaProps) {
   };
 
   return stravaContent.distance != null ? (
-    <div className="sport flex items-center gap-2">
+    <div className="sport flex items-center gap-2 min-[2560px]:gap-3">
       <Bicycle
         size={18}
         weight="bold"
-        className="text-poster-dark/50"
+        className="text-poster-dark/50 min-[2560px]:!h-[1.2vw] min-[2560px]:!w-[1.2vw]"
       />
-      <span className="text-sm font-bold text-poster-dark/70">
+      <span className="text-sm min-[2560px]:text-[1vw] font-bold text-poster-dark/70">
         <AnimatedNumber
           target={Number.parseFloat(stravaContent.distance)}
           decimals={1}
           suffix=" km"
         />
       </span>
-      <span className="text-poster-dark/30 text-[0.7rem] uppercase tracking-widest">
+      <span className="text-poster-dark/30 text-[0.7rem] min-[2560px]:text-[0.8vw] uppercase tracking-widest">
         {stravaContent.currentYear}
       </span>
     </div>

--- a/components/themeSelector/themeSelector.tsx
+++ b/components/themeSelector/themeSelector.tsx
@@ -19,9 +19,15 @@ const themes: Theme[] = [
 
 const STORAGE_KEY = "theme";
 
+const SIZES = {
+  default: { collapsed: "40px", padding: "12px", label: "60px" },
+  large: { collapsed: "48px", padding: "16px", label: "80px" },
+};
+
 export default function ThemeSelector() {
   const [active, setActive] = useState("terracotta");
   const [hoveredTheme, setHoveredTheme] = useState<string | null>(null);
+  const [isLargeScreen, setIsLargeScreen] = useState(false);
 
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
@@ -29,6 +35,13 @@ export default function ThemeSelector() {
       setActive(stored);
       document.documentElement.setAttribute("data-theme", stored);
     }
+
+    const mediaQuery = window.matchMedia("(min-width: 2560px)");
+    setIsLargeScreen(mediaQuery.matches);
+    const handler = (event: MediaQueryListEvent) =>
+      setIsLargeScreen(event.matches);
+    mediaQuery.addEventListener("change", handler);
+    return () => mediaQuery.removeEventListener("change", handler);
   }, []);
 
   const handleSelect = useCallback((themeId: string) => {
@@ -46,9 +59,11 @@ export default function ThemeSelector() {
     setHoveredTheme(null);
   }, []);
 
+  const sizes = isLargeScreen ? SIZES.large : SIZES.default;
+
   return (
     <div
-      className="fixed right-2 top-1/2 z-50 flex -translate-y-1/2 flex-col items-end gap-0 animate-fade-in-slide-right"
+      className="fixed right-2 min-[2560px]:right-4 top-1/2 z-50 flex -translate-y-1/2 flex-col items-end gap-0 min-[2560px]:gap-1 animate-fade-in-slide-right"
       style={{ animationDelay: "1s" }}
     >
       {themes.map((theme) => {
@@ -62,10 +77,10 @@ export default function ThemeSelector() {
             onClick={() => handleSelect(theme.id)}
             onPointerEnter={() => handlePointerEnter(theme.id)}
             onPointerLeave={handlePointerLeave}
-            className="flex items-center justify-end h-10 gap-2 pr-3 rounded-full transition-all duration-300 ease-out focus:outline-none"
+            className="flex items-center justify-end h-10 min-[2560px]:h-12 gap-2 min-[2560px]:gap-3 pr-3 min-[2560px]:pr-4 rounded-full transition-all duration-300 ease-out focus:outline-none"
             style={{
-              width: isExpanded ? "auto" : "40px",
-              paddingLeft: isExpanded ? "12px" : "0",
+              width: isExpanded ? "auto" : sizes.collapsed,
+              paddingLeft: isExpanded ? sizes.padding : "0",
               backgroundColor: isExpanded
                 ? `color-mix(in srgb, ${theme.swatch} 20%, transparent)`
                 : "transparent",
@@ -73,10 +88,10 @@ export default function ThemeSelector() {
             aria-label={`Theme: ${theme.label}`}
           >
             <span
-              className="text-[0.65rem] font-bold tracking-wider whitespace-nowrap overflow-hidden transition-all duration-300 ease-out"
+              className="text-[0.65rem] min-[2560px]:text-sm font-bold tracking-wider whitespace-nowrap overflow-hidden transition-all duration-300 ease-out"
               style={{
                 fontFamily: "var(--font-shippori)",
-                maxWidth: isExpanded ? "60px" : "0",
+                maxWidth: isExpanded ? sizes.label : "0",
                 opacity: isExpanded ? 1 : 0,
                 color: theme.swatch,
               }}
@@ -84,7 +99,7 @@ export default function ThemeSelector() {
               {theme.label}
             </span>
             <span
-              className="block h-4 w-4 shrink-0 rounded-full transition-all duration-300"
+              className="block h-4 w-4 min-[2560px]:h-5 min-[2560px]:w-5 shrink-0 rounded-full transition-all duration-300"
               style={{
                 backgroundColor: theme.swatch,
                 boxShadow: isActive


### PR DESCRIPTION
Add min-[2560px] breakpoints with viewport-relative units across all components so text, icons, spacing and containers scale proportionally on large displays. Theme selector uses matchMedia to adapt inline style values.